### PR TITLE
Fix qrc and descriptor limits

### DIFF
--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -908,6 +908,9 @@ suggest_xdg_basedir() {
 
 validatesandboxing() {
     while read filename; do
+        # TODO: fix prober, but this seems to work around the out of file
+        # descriptor issue
+        (true)
         filename=${filename#./}
         while read match; do
             validation_error "/$filename" "Hardcoded path: $match"


### PR DESCRIPTION
Line 635: qrc imports do not need to be in the form 'qrc:///foo' it can also be 'qrc:/foo'

validatesandboxing() revert 51f68fefe79c7 since that breaks functionality, seems that (true) thingy works around the issue for the moment
