### PR TITLE
[conf] QtFeedback due to messed up naming removed

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -35,7 +35,6 @@ libQt5Xml.so.5
 libQt5DBus.so.5
 libQt5WebKit.so.5
 libQt5Sensors.so.5
-libQt0Feedback.so.0
 
 # Various additional libraries that are useful
 libmlite5.so.0

--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -19,7 +19,6 @@ QtQuick.Window 2.1
 QtMultimedia 5.0
 QtWebKit 3.0
 QtSensors 5.0
-QtFeedback 5.0
 QtGraphicalEffects 1.0
 
 # ContextKit

--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -56,9 +56,7 @@ qt5-qtsvg
 qt5-qtgraphicaleffects
 
 # Qt Modules
-qt5-qtfeedback
 qt5-qtmultimedia
-qt5-qtfeedback
 
 # Image format plugins
 qt5-plugin-imageformat-gif


### PR DESCRIPTION
QtFeedback has messed up library naming, this needs to be clean up
before it can be accepted in Harbour.
