### PR TITLE
[conf] allow also newer pyotherside-qml-plugin

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -26,3 +26,6 @@ org.freedesktop.contextkit 1.0
 
 # Python support
 io.thp.pyotherside 1.0
+io.thp.pyotherside 1.1
+io.thp.pyotherside 1.2
+io.thp.pyotherside 1.3


### PR DESCRIPTION
pyotherside got developed further since first pull request preparation was done, so we should also allow the newer ones.
