### PR TITLE
Allow harbour apps to have settings

### DIFF
--- a/rpmvalidation.conf
+++ b/rpmvalidation.conf
@@ -14,6 +14,9 @@ ICON_NAME_PATH="$PROG_PATH/share/icons/hicolor/@@SIZE@@/apps/$NAME.png"
 LIB_DEBUG_NAME="$PROG_PATH/lib/debug"
 SRC_DEBUG_NAME="$PROG_PATH/src/debug"
 
+SETTINGS_PLUGIN_JSON="$PROG_PATH/share/jolla-settings/entries/$NAME.json"
+TRANSLATIONS_REGEX="$PROG_PATH/share/translations/$NAME(-.+)?.qm"
+
 #
 # Libraries
 #

--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013 - 2014 Jolla Ltd.
+# Copyright (C) 2013 - 2016 Jolla Ltd.
 # Contact: Reto Zingg <reto.zingg@jolla.com>
 #
 # This file is part of the SailfishOS SDK
@@ -445,7 +445,7 @@ validatepaths () {
             validation_error "$rpm_file" "Installation not allowed in this location"
         fi
     done < <(eval "$FIND . -depth \( \( ! -type d \) -o \( -type d -a -empty \) \) $OPT_SORT" \
-        | $EGREP -v -E "^./($BIN_NAME|$SHARE_NAME/.*|$DESKTOP_NAME|$ICON_NAMES_REGEX)$")
+        | $EGREP -v -E "^./($BIN_NAME|$SHARE_NAME/.*|$DESKTOP_NAME|$ICON_NAMES_REGEX|$SETTINGS_PLUGIN_JSON|$TRANSLATIONS_REGEX)$")
 
     # Accidentally added files
     while read filename; do


### PR DESCRIPTION
This patch allows harbour apps to install its settings `.json` file to `/usr/share/jolla-settings/entries` and install translations to `/usr/share/translations`. Everything else (including settings qml files) can remain in the app specific area as long as `.json` file points there.
