### PR TITLE
Add PyOtherSide 1.4 & 1.5 to allowed QML imports

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -58,6 +58,8 @@ io.thp.pyotherside 1.0
 io.thp.pyotherside 1.1
 io.thp.pyotherside 1.2
 io.thp.pyotherside 1.3
+io.thp.pyotherside 1.4
+io.thp.pyotherside 1.5
 
 # Nemo QML modules
 Nemo.Notifications 1.0


### PR DESCRIPTION
PyOtherSide has been updated to 1.5 in Sailfish OS quite long ago, but the allowed imports file has apparently not been updated. So add versions 1.4 & 1.5 of the PyOtherSide QML module to the allowed QML import list so that developers of Python/QML applications can make use of the new features and fixes added.