### PR TITLE
[harbour-validator] Allow providing application() capability

### DIFF
--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -970,7 +970,7 @@ validaterpmprovides() {
 
     for provide in $PROVIDES; do
         case "$provide" in
-            ${NAME}*)
+            ${NAME}*|"application()"|"application(${NAME}.desktop)")
                 # Do nothing
                 ;;
             lib*.so.*|lib*.so)


### PR DESCRIPTION
This is declared implicitly now after RPM upgrade