### PR TITLE
Remove libcontextkit-statefs-qt5.so from allowed libs. Fixes JB#49921

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -80,9 +80,6 @@ libwayland-client.so.0
 libwayland-cursor.so.0
 libwayland-egl.so.1
 
-# ContextKit
-libcontextkit-statefs-qt5.so
-
 # Multimedia
 libogg.so.0
 libvorbis.so.0


### PR DESCRIPTION
Contextkit qml interface got a reimplementation without statefs dependency,
and there were only couple apps in jolla-store using the c++ library.