### PR TITLE
allow binaries with C assert in validatesandboxing

### DIFF
--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -1072,7 +1072,7 @@ validatesandboxing() {
         while read match; do
             validation_error "/$filename" "Hardcoded path: $match"
             suggest_xdg_basedir "$filename"
-        done < <(strings "$filename" | $EGREP "/home/[^.][^/]*/")
+        done < <(strings "$filename" | $EGREP "/home/(nemo|defaultuser)/")
     done < <(eval $FIND . ! -type d $OPT_SORT)
 }
 


### PR DESCRIPTION
C asserts includes path of source files to messages.
So at the end, binaries contains strings with paths inside SDK.
`/home/mersdk/share/...` usually.

`validatesandboxing()` expression that rejects all paths starting
with `/home/` is too strict. We should check just paths that may be
hardcoded in binaries as accident: `/home/nemo/` and `/home/defaultuser/`.