### PR TITLE
[harbour-validator] Allow python3-sqlite. Fixes JB#51431

### DIFF
--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -74,6 +74,7 @@ libsqlite3.so.0
 # Python support
 pyotherside-qml-plugin-python3-qt5
 python3-gobject
+python3-sqlite
 
 # libxml2
 libxml2


### PR DESCRIPTION
Previously python3-sqlite was included in python3 package, so it was
not necessary to install it separately. Now that it is a separate
package we need to allow it in dependencies.