### PR TITLE
allow qml import Sailfish.Share

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -7,6 +7,7 @@
 # Sailfish API
 Sailfish.Silica 1.0
 Sailfish.Pickers 1.0
+Sailfish.Share 1.0
 
 # Qt 5.0
 QtQml 2.0


### PR DESCRIPTION
With SFOS 4.2 there was change in sharing API. Silica page
`Sailfish.TransferEngine.SharePage` is not available anymore.
With the the new API, application should use new Silica component
`ShareAction` from `Sailfish.Share` package.

This commit allows to use this import by 3rd party applications
in Jolla Harbour.

see https://github.com/sailfishos/sdk-harbour-rpmvalidator/issues/135