### PR TITLE
Allow X-Sailjail/ExecDBus key

### DIFF
--- a/allowed_sailjailkeys.conf
+++ b/allowed_sailjailkeys.conf
@@ -2,3 +2,4 @@
 Permissions
 OrganizationName
 ApplicationName
+ExecDBus

--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013 - 2021 Jolla Ltd.
+# Copyright (C) 2013 - 2022 Jolla Ltd.
 # Copyright (C) 2018 - 2020 Open Mobile Platform LLC.
 # Contact: http://jolla.com/
 #
@@ -579,6 +579,20 @@ validatesailjailkey() {
             echo ApplicationName=$value
             validation_error "ApplicationName contains illegal characters"
             INFO_MSG_PRINTED=1
+        fi
+    elif [[ $key == ExecDBus ]]; then
+        if [[ $USES_SAILFISH_QML_LAUNCHER -eq 0 ]]; then
+            if [[ ! $value =~ ^$NAME(|[[:space:]]+[A-Za-z_-][A-Z0-9a-z_-]*)$ ]]; then
+                echo ExecDBus=$value
+                validation_error "ExecDBus has invalid argument(s)"
+                INFO_MSG_PRINTED=1
+            fi
+        else
+            if [[ ! $value =~ ^sailfish-qml[[:space:]]+$NAME(|[[:space:]]+[A-Za-z_-][A-Z0-9a-z_-]*)$ ]]; then
+                echo ExecDBus=$value
+                validation_error "ExecDBus has invalid argument(s)"
+                INFO_MSG_PRINTED=1
+            fi
         fi
     fi
 }


### PR DESCRIPTION
Allow `ExecDBus` key in `X-Sailjail` section. When defined, require the value to be the same as `Desktop Entry/Exec` value but with an additional and optional argument which allows to detect D-Bus activation.

I limited this to typical arguments like `--daemon` or `-prestart` but it can be also for example `dbus` without leading `-`. This doesn't allow field codes (e.g. `%f`) which would be useless in this case. Only one argument allowed, which is a bit arbitrary choice but you shouldn't need more than that. This all can be discussed of course.

Also I guess we should consider how we want to express this in error messages. If there should be links to some information etc.