### PR TITLE
[harbour-validator] Mention backwards compatibility in documentation

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -15,9 +15,17 @@ Sailfish.WebView.Controls 1.0
 Sailfish.WebView.Pickers 1.0
 Sailfish.WebView.Popups 1.0
 Sailfish.WebEngine 1.0
+# We make no quarantees of backwards compatibility between releases. 
+# Supported since Sailfish OS 4.5.0.
 Sailfish.Secrets 1.0
+# We make no quarantees of backwards compatibility between releases. 
+# Supported since Sailfish OS 4.5.0.
 Sailfish.Crypto 1.0
+# We make no quarantees of backwards compatibility between releases. 
+# Supported since Sailfish OS 4.5.0.
 Sailfish.Media 1.0
+# We make no quarantees of backwards compatibility between releases. 
+# Supported since Sailfish OS 4.5.0.
 Sailfish.Contacts 1.0
 
 # ### Amber Web Authorization framework
@@ -91,4 +99,6 @@ Nemo.DBus 2.0
 Nemo.Configuration 1.0
 Nemo.Thumbnailer 1.0
 Nemo.KeepAlive 1.2
+# We make no quarantees of backwards compatibility between releases. 
+# Supported since Sailfish OS 4.5.0.
 org.nemomobile.contacts 1.0


### PR DESCRIPTION
The newly allowed APIs are not considered stable, so it's worth
warning about it in the docs. Fixes JB#58710