### PR TITLE
[harbour-validator] Allow Nemo.Time 1.0

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -110,6 +110,7 @@ Nemo.DBus 2.0
 Nemo.Configuration 1.0
 Nemo.Thumbnailer 1.0
 Nemo.KeepAlive 1.2
+Nemo.Time 1.0
 # We make no quarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 org.nemomobile.contacts 1.0


### PR DESCRIPTION
Nemo.Time is super simple, and basically only used to show a wall clock.

For context, see [my forum post about Whisperfish in the Jolla store](https://forum.sailfishos.org/t/what-apis-are-missing-from-harbour/4017/51?u=rubdos)