### PR TITLE
QML QtPositioning package dependency

### DIFF
--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -73,12 +73,12 @@ qt5-qtdeclarative-import-particles2
 qt5-qtdeclarative-qtquickparticles
 qt5-qtsvg
 qt5-qtgraphicaleffects
-qt5-qtdeclarative-import-positioning
 qt5-qtdeclarative-import-sensors
 qt5-qtquickcontrols-layouts
 qt5-qtdeclarative-import-models2
 qt5-qtwebsockets
 qml(QtLocation)
+qml(QtPositioning)
 
 # ### Nemo QML Imports
 nemo-qml-plugin-notifications-qt5

--- a/deprecated_requires.conf
+++ b/deprecated_requires.conf
@@ -4,3 +4,5 @@
 # ### Deprecated in Sailfish OS 5.1
 libcrypto.so.1.1?((OPENSSL_1_1_*))
 libssl.so.1.1?((OPENSSL_1_1_*))
+# Use qml(QtPositioning) instead
+qt5-qtdeclarative-import-positioning

--- a/doc/apis.md
+++ b/doc/apis.md
@@ -56,6 +56,13 @@ The following QML Imports are no longer allowed:
 % for section in dropped_qmlimports:
 ${makelist("Dropped_QML_Imports", section)}\
 % endfor
+${'##'} Deprecated package dependencies
+
+The following package dependencies should now longer be used in new code. They will be dropped from allowed dependencies in a future release:
+
+% for section in deprecated_requires:
+${makelist("Deprecated_Requires", section)}\
+% endfor
 <%def name="makelist(section, subsection)">\
 % if len(subsection) > 1:
 ${subsection[0]}

--- a/doc/gen_doc.py
+++ b/doc/gen_doc.py
@@ -93,6 +93,8 @@ def main(argv):
         os.path.join(source_dir, 'deprecated_qmlimports.conf'))
     dropped_qmlimports = read_conf(
         os.path.join(source_dir, 'dropped_qmlimports.conf'))
+    deprecated_requires = read_conf(
+        os.path.join(source_dir, 'deprecated_requires.conf'))
     disallowed_qmlimports_patterns = read_conf(
         os.path.join(source_dir, 'disallowed_qmlimport_patterns.conf'))
     allowed_permissions = read_conf(
@@ -108,6 +110,7 @@ def main(argv):
         dropped_libraries=dropped_libraries,
         deprecated_qmlimports=deprecated_qmlimports,
         dropped_qmlimports=dropped_qmlimports,
+        deprecated_requires=deprecated_requires,
         disallowed_qmlimports_patterns=disallowed_qmlimports_patterns,
         allowed_permissions=allowed_permissions
     )


### PR DESCRIPTION
This PR fixes two issues:
 - First issue is that the package dependencies for the QML imports for QtPositioning and QtLocation were allowed in a different way: One using package name and the other using capability. This PR unifies the rules, making it more logical for developers
 - Second issue is that deprecated package dependencies were not included in rendered documentation. This is a bit unfortunate as there are two deprecated packages already in 5.1, so you might want to render the documentation for 5.1 with the second commit of this PR.