### PR TITLE
Replace quarantee with guarantee in comments

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -28,7 +28,7 @@ libsailfishwebengine.so.1
 libamberwebauthorization.so.1
 
 # ### Sailfish Accounts library
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 libsailfishaccounts.so.0
 
@@ -119,6 +119,6 @@ libSDL2_net-2.0.so.0
 libSDL2_ttf-2.0.so.0
 
 # ### BluezQt
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 libKF5BluezQt.so.6

--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -15,25 +15,25 @@ Sailfish.WebView.Controls 1.0
 Sailfish.WebView.Pickers 1.0
 Sailfish.WebView.Popups 1.0
 Sailfish.WebEngine 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Secrets 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Crypto 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Media 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Contacts 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Accounts 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Bluetooth 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 Sailfish.Telephony 1.0
 
@@ -111,11 +111,11 @@ Nemo.Configuration 1.0
 Nemo.Thumbnailer 1.0
 Nemo.KeepAlive 1.2
 Nemo.Time 1.0
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 org.nemomobile.contacts 1.0
 
 # ### BluezQt
-# We make no quarantees of backwards compatibility between releases. 
+# We make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 org.kde.bluezqt 1.0

--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -132,7 +132,7 @@ python3dist(zope-interface)
 python3dist(sortedcontainers)
 python3dist(toml)
 python3dist(twisted)
-# While we allow Pillow, we make no quarantees of backwards compatibility between releases. 
+# While we allow Pillow, we make no guarantees of backwards compatibility between releases. 
 # Supported since Sailfish OS 4.5.0.
 python3dist(pillow)
 # Supported since Sailfish OS 4.5.0


### PR DESCRIPTION
The documentation is generated from the comments. The spelling was already fixed on the docs.sailfishos.org, but it will always end up wrong again unless it is fixed here.